### PR TITLE
FIx sqlite3.OperationalError: no such column: name

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ _DB.execute(
     dep_name TEXT,
     dep_specifier TEXT,
     extra TEXT DEFAULT NULL,
-    PRIMARY KEY (name, version, dep_name, dep_specifier)
+    PRIMARY KEY (package_name, version, dep_name, dep_specifier)
   );
 """
 )


### PR DESCRIPTION
With no `pypi.db` file:

```console
$ python main.py
Traceback (most recent call last):
  File "/Users/huvankem/github/pypi-data/main.py", line 70, in <module>
    _DB.execute(
sqlite3.OperationalError: no such column: name
```


Looks like something missed in https://github.com/sethmlarson/pypi-data/commit/5056dede268daecee40a4b54fa14beb45bfc546c which made this change:


```diff
_DB.execute(
    """
  CREATE TABLE IF NOT EXISTS deps (
-   name TEXT,
+   package_name TEXT,
    version TEXT,
    dep_name TEXT,
    dep_specifier TEXT,
    extra TEXT DEFAULT NULL,
    PRIMARY KEY (name, version, dep_name, dep_specifier)
  );
"""
)
