### PR TITLE
Test on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: requirements.in
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           python -m pip install -U pytest
-          python -m pip install -r requirements.in
+          python -m pip install -r requirements.txt
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11-dev"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.in
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pytest
+          python -m pip install -r requirements.in
+
+      - name: Test
+        run: |
+          pytest


### PR DESCRIPTION
Installing from unpinned `requirements.in` because it from `requirments.txt`:

```
ERROR: Could not find a version that satisfies the requirement psl==2021.1.4 (from versions: 2022.6.13, 2022.7.4, 2022.8.8, 2022.8.15, 2022.8.29, 2022.9.26)
ERROR: No matching distribution found for psl==2021.1.4
```

https://github.com/hugovk/pypi-data/actions/runs/3154271464/jobs/5131678659

I don't often use pip-tools, and running the command from the top of the `.txt`:

```sh
pip-compile --generate-hashes --output-file=requirements.txt --pip-args='--only-binary=":all:"' requirements.in
```

Failed with the same error.

---

Testing on 3.9+ because I'm using 3.10 and added 3.9+ type hints:

```
    def get_project_urls(info: dict) -> list[tuple[str, str, str]]:
E   TypeError: 'type' object is not subscriptable
```

https://github.com/hugovk/pypi-data/actions/runs/3154300580/jobs/5131739856

We can add `from __future__ import annotations` if you'd like 3.7+?
