### PR TITLE
Remove no-longer-useful URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,8 +179,8 @@ def fetch_checks_for_package(package_name):
 def get_project_urls(info: dict) -> list[tuple[str, str, str]]:
     names_urls = [
         ("docs_url", info.get("docs_url")),
-        ("Downloads", info.get("download_url")),
-        ("Homepage", info.get("home_page")),
+        ("download_url", info.get("download_url")),
+        ("home_page", info.get("home_page")),
     ]
 
     if info.get("project_urls"):

--- a/main.py
+++ b/main.py
@@ -178,11 +178,9 @@ def fetch_checks_for_package(package_name):
 
 def get_project_urls(info: dict) -> list[tuple[str, str, str]]:
     names_urls = [
-        ("bugtrack_url", info.get("bugtrack_url")),
         ("docs_url", info.get("docs_url")),
         ("Downloads", info.get("download_url")),
         ("Homepage", info.get("home_page")),
-        ("project_url", info.get("project_url")),
     ]
 
     if info.get("project_urls"):


### PR DESCRIPTION
Follow on from https://github.com/sethmlarson/pypi-data/pull/16:

* Remove `bugtrack_url`? Looks like it was [dropped from Warehouse](https://github.com/pypi/warehouse/blob/39daea188d2e1e6494c50753cd48cb5a8da3e8c4/warehouse/migrations/versions/e82c3a017d60_remove_unused_columns.py#L30) and I've not found any results for it (I built the first 6% of the database).

* `project_url` seems to be always generated as `https://pypi.org/project/{project}/` and subsequently ditched by `parse_project_url`, skip this too.

