### PR TITLE
Use future typing annotations to support Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
       - uses: actions/checkout@v3

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import contextlib
 import csv
 import itertools


### PR DESCRIPTION
Follow on from https://github.com/sethmlarson/pypi-data/pull/17.