### PR TITLE
Update CI versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: requirements.txt
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
3.7 is failing due to a walrus: https://github.com/sethmlarson/pypi-data/actions/runs/6709793648/job/18233608593

Removed `cache-dependency-path: requirements.txt` because it's a default: https://github.com/actions/setup-python#caching-packages-dependencies
