### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ from wheel_filename import InvalidFilenameError, parse_wheel_filename
 
 MAX_WORKERS = 16
 GOOGLE_ASSURED_OSS_PACKAGES = set()
-DOWNLOADS_URL = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages-30-days.min.json"
+DOWNLOADS_URL = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages.min.json"
 
 @contextlib.contextmanager
 def locked_db():


### PR DESCRIPTION
To stay under quota, the file now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.